### PR TITLE
src-601 add pre-wrap style to message content to support new line

### DIFF
--- a/src/components/communications/Message/Message.scss
+++ b/src/components/communications/Message/Message.scss
@@ -5,11 +5,13 @@
   flex-direction: row;
   align-items: flex-start;
 
-  &--top, &--single {
+  &--top,
+  &--single {
     margin-top: 1rem;
   }
 
-  &--bottom, &--single {
+  &--bottom,
+  &--single {
     margin-bottom: 2rem;
   }
 
@@ -28,7 +30,7 @@
 
   &--meta {
     display: inline-flex;
-    color: #929CA6;
+    color: #929ca6;
     font-size: 0.75rem;
     padding: 0 0.75rem;
     margin: 0.125rem 0 -1rem 0;
@@ -45,17 +47,20 @@
     border-radius: 0.15rem;
     display: inline-flex;
     margin: 0.125rem 0;
+    white-space: pre-wrap;
   }
 
   &--image {
     margin: 0 0.5rem;
   }
 
-  &--top &--meta, &--middle &--meta {
+  &--top &--meta,
+  &--middle &--meta {
     display: none;
   }
 
-  &--top &--image, &--middle &--image {
+  &--top &--image,
+  &--middle &--image {
     visibility: hidden;
   }
 
@@ -65,11 +70,13 @@
     align-items: flex-start;
   }
 
-  &--top &--content:first-child, &--single &--content:first-child {
+  &--top &--content:first-child,
+  &--single &--content:first-child {
     border-top-left-radius: 1.5rem;
   }
 
-  &--bottom &--content:last-child, &--single &--content:last-child {
+  &--bottom &--content:last-child,
+  &--single &--content:last-child {
     border-bottom-left-radius: 1.5rem;
   }
 


### PR DESCRIPTION
# Context

We've recently added support in Messages to render new line characters by using the `white-space: pre-wrap` style. This PR mirrors that support.

# Visual

*Elements Message*
<img width="1182" alt="Screen Shot 2022-01-28 at 4 39 34 PM" src="https://user-images.githubusercontent.com/177652/151625290-07bede37-1d1f-4aa5-82df-eb5c08c42007.png">

*Same message in Harness*
<img width="1155" alt="Screen Shot 2022-01-28 at 4 38 33 PM" src="https://user-images.githubusercontent.com/177652/151625280-f3c0d5cd-2658-4d38-b1b1-8fa4a6da2e72.png">

